### PR TITLE
Added multiple package uninstallation and uninstall using install_manifest.txt

### DIFF
--- a/include/FSFuncs.hpp
+++ b/include/FSFuncs.hpp
@@ -92,13 +92,6 @@ std::string GetPackageDir( const Package & pkg );
 //	PACKAGE_TMP/<package name>/<version string>
 std::string GetPackageVersionDir( const Package & pkg );
 
-// Fetches extra directories which are created when copying installation
-// files. These directories are then used to remove the directories at the
-// the time of uninstallation.
-void FetchExtraDirs( const Package & pkg,
-		const std::map< std::string, std::vector< DirFile > > & copyfiles,
-		std::vector< std::string > & fileanddir );
-
 // Removes the files and directories which are copied when package is installed.
 // The file/directory in data is erased when it's removed.
 // Returns true on success, false if not.

--- a/include/PackageManagement/PackageData.hpp
+++ b/include/PackageManagement/PackageData.hpp
@@ -24,6 +24,7 @@ struct Package
 	std::string file;
 
 	std::string buildmode;
+	std::string cleanupdirs;
 };
 
 // Also, DirFile is used in FSFuncs to fetch the directory and file which resides

--- a/include/PackageManagement/PackageInstaller.hpp
+++ b/include/PackageManagement/PackageInstaller.hpp
@@ -28,6 +28,13 @@ bool CopyFiles( const Package & pkg,
 // and vectors of files which are copied.
 std::map< std::string, std::vector< DirFile > > GetCopyList( const Package & pkg, bool & use_framework );
 
+// Fetches extra directories which are created when copying installation
+// files. These directories are then used to remove the directories at the
+// the time of uninstallation.
+void FetchExtraDirs( const Package & pkg,
+		const std::map< std::string, std::vector< DirFile > > & copyfiles,
+		std::vector< std::string > & fileanddir );
+
 // This function is called when Installation fails and something has been altered ( copied ).
 // It will remove all the copied files therefore, system is left as it was before.
 void RevertInstallation( const Package & pkg, std::vector< std::string > & data );

--- a/include/PackageManagement/PackageUninstaller.hpp
+++ b/include/PackageManagement/PackageUninstaller.hpp
@@ -9,6 +9,11 @@
 // Otherwise, it will execute the uninstall commands and let them do the job.
 // The input args is also provided as vector to display error messages.
 // Returns true on success, false on failure.
-bool UninstallArchive( const Package & pkg, const std::vector< std::string > & args );
+bool UninstallArchive( const Package & pkg );
+
+// Some packages provide install_manifests which contains files to remove,
+// instead of providing actual "make uninstall" command.
+// This function handles that should "make uninstall" fail.
+bool UninstallUsingInstallManifest( const Package & pkg );
 
 #endif // PACKAGEUNINSTALLER_HPP

--- a/include/PackageManager.hpp
+++ b/include/PackageManager.hpp
@@ -27,6 +27,12 @@ public:
 	// Returns 0 if installed correctly, anything else if not.
 	int InstallMultiplePackages( std::vector< std::string > & packages, bool forceinstall = false );
 
+	// Uninstalls multiple packages by calling UninstallPackage on each.
+	// If any package failes to uninstall, it will stop the process, neglecting the subsequent
+	// packages.
+	// Returns 0 if uninstalled correctly, anthing else if not.
+	int UninstallMultiplePackages();
+
 	// Installs a single package in the following manner:
 	//	check if package exists -> check already installed ->
 	//	fetch ( download ) package -> extract package ->

--- a/src/FSFuncs.cpp
+++ b/src/FSFuncs.cpp
@@ -310,39 +310,6 @@ std::string GetPackageVersionDir( const Package & pkg )
 	return PACKAGE_TMP + pkg.name + "/" + pkg.version;
 }
 
-void FetchExtraDirs( const Package & pkg,
-		const std::map< std::string, std::vector< DirFile > > & copyfiles,
-		std::vector< std::string > & fileanddir )
-{
-	for( auto type : copyfiles ) {
-		std::string prefix;
-		if( type.first == "inc" ) {
-			prefix = PACKAGE_INCLUDE_INSTALL_DIR;
-		}
-		if( type.first == "lib" ) {
-			prefix = PACKAGE_LIBRARY_INSTALL_DIR;
-		}
-		if( type.first == "fw" ) {
-			prefix = PACKAGE_FRAMEWORKS_INSTALL_DIR;
-		}
-		for( auto data : type.second ) {
-			std::string dir = prefix + data.dir;
-			if( dir.empty() )
-				continue;
-
-			if( std::find( fileanddir.begin(), fileanddir.end(), dir ) != fileanddir.end() )
-				continue;
-
-			if( dir == PACKAGE_INCLUDE_INSTALL_DIR ||
-				dir == PACKAGE_LIBRARY_INSTALL_DIR ||
-				dir == PACKAGE_FRAMEWORKS_INSTALL_DIR )
-				continue;
-
-			fileanddir.push_back( dir );
-		}
-	}
-}
-
 bool RemoveCopiedData( const Package & pkg, std::vector< std::string > & data )
 {
 	for( auto it = data.begin(); it != data.end(); ) {

--- a/src/INI_System/INI_Parser.cpp
+++ b/src/INI_System/INI_Parser.cpp
@@ -59,7 +59,7 @@ namespace Electrux
 				}
 			}
 
-			if( ch == '=' )
+			if( ch == '=' && !found_equals )
 				found_equals = true;
 			else
 				(found_equals) ? val += ch : key += ch;

--- a/src/PackageManagement/PackageConfig.cpp
+++ b/src/PackageManagement/PackageConfig.cpp
@@ -8,6 +8,7 @@
 #include "../../include/StringFuncs.hpp"
 #include "../../include/DisplayFuncs.hpp"
 #include "../../include/FSFuncs.hpp"
+#include "../../include/DisplayExecute.hpp"
 #include "../../include/PackageManagement/PackageData.hpp"
 #include "../../include/INI_System/INI_Parser.hpp"
 
@@ -53,6 +54,7 @@ bool PackageConfig::GetPackage( const std::string & packagename, Package & pkg )
 	if( pkg.type == "Source" ) {
 		parser.GetDataString( pkg.type, "File", pkg.file );
 		parser.GetDataString( pkg.type, "BuildMode", pkg.buildmode );
+		parser.GetDataString( pkg.type, "CleanupDirectories", pkg.cleanupdirs );
 	}
 	else if( pkg.type == "Binary" ) {
 		parser.GetDataString( pkg.type, prefix + "File", pkg.file );
@@ -82,6 +84,10 @@ bool PackageConfig::HandlePkgDirs()
 		return false;
 
 	if( ARCH == MAC && !LocExists( PACKAGE_FRAMEWORKS_INSTALL_DIR ) && CreateDir( PACKAGE_FRAMEWORKS_INSTALL_DIR, false ) != 0 )
+		return false;
+	
+	if( !LocExists( PACKAGE_INSTALL_DIR + "lib64" ) &&
+		DispExecuteNoErr( "ln -s " + PACKAGE_LIBRARY_INSTALL_DIR + " " + PACKAGE_INSTALL_DIR + "lib64", false ) != 0 )
 		return false;
 
 	return true;

--- a/src/PackageManagement/PackageInstaller.cpp
+++ b/src/PackageManagement/PackageInstaller.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 

--- a/src/PackageManagement/PackageInstaller.cpp
+++ b/src/PackageManagement/PackageInstaller.cpp
@@ -150,6 +150,39 @@ std::map< std::string, std::vector< DirFile > > GetCopyList( const Package & pkg
 	return list;
 }
 
+void FetchExtraDirs( const Package & pkg,
+		const std::map< std::string, std::vector< DirFile > > & copyfiles,
+		std::vector< std::string > & fileanddir )
+{
+	for( auto type : copyfiles ) {
+		std::string prefix;
+		if( type.first == "inc" ) {
+			prefix = PACKAGE_INCLUDE_INSTALL_DIR;
+		}
+		if( type.first == "lib" ) {
+			prefix = PACKAGE_LIBRARY_INSTALL_DIR;
+		}
+		if( type.first == "fw" ) {
+			prefix = PACKAGE_FRAMEWORKS_INSTALL_DIR;
+		}
+		for( auto data : type.second ) {
+			std::string dir = prefix + data.dir;
+			if( dir.empty() )
+				continue;
+
+			if( std::find( fileanddir.begin(), fileanddir.end(), dir ) != fileanddir.end() )
+				continue;
+
+			if( dir == PACKAGE_INCLUDE_INSTALL_DIR ||
+				dir == PACKAGE_LIBRARY_INSTALL_DIR ||
+				dir == PACKAGE_FRAMEWORKS_INSTALL_DIR )
+				continue;
+
+			fileanddir.push_back( dir );
+		}
+	}
+}
+
 void RevertInstallation( const Package & pkg, std::vector< std::string > & data )
 {
 	if( !RemoveCopiedData( pkg, data ) ) {

--- a/src/PackageManagement/PackageUninstaller.cpp
+++ b/src/PackageManagement/PackageUninstaller.cpp
@@ -91,6 +91,8 @@ bool UninstallArchive( const Package & pkg )
 	}
 
 	ChangeWorkingDir( cwd );
+
+	DispColoredData( TICK, GREEN, true );
 	return true;
 }
 
@@ -126,7 +128,5 @@ bool UninstallUsingInstallManifest( const Package & pkg )
 	}
 
 	file.close();
-
-	DispColoredData( TICK, GREEN, true );
 	return true;
 }

--- a/src/PackageManagement/PackageUninstaller.cpp
+++ b/src/PackageManagement/PackageUninstaller.cpp
@@ -72,6 +72,23 @@ bool UninstallArchive( const Package & pkg )
 	else {
 		DispColoredData( TICK, GREEN, true );
 	}
+	
+	if( pkg.cleanupdirs.empty() )
+		return true;
+
+	DispColoredData( " =>", "Cleaning directories up ... ", SECOND_COL, FIRST_COL, false );
+	auto cleanupdirs = DelimStringToVector( pkg.cleanupdirs );
+
+	for( auto cleanupdir : cleanupdirs ) {
+		if( DispExecuteNoErr( "rm -rf " + PACKAGE_INSTALL_DIR + cleanupdir ) != 0 ) {
+			DispColoredData( CROSS, RED, true );
+			DispColoredData( " =>", "Unable to remove directory:",
+					PACKAGE_INSTALL_DIR + cleanupdir, RED, RED, CYAN, false );
+			DispColoredData( " !", CROSS, RED, RED, true );
+			ChangeWorkingDir( cwd );
+			return false;
+		}
+	}
 
 	ChangeWorkingDir( cwd );
 	return true;
@@ -109,22 +126,6 @@ bool UninstallUsingInstallManifest( const Package & pkg )
 	}
 
 	file.close();
-
-	if( pkg.cleanupdirs.empty() )
-		return true;
-
-	DispColoredData( " =>", "Cleaning directories up ... ", SECOND_COL, FIRST_COL, false );
-	auto cleanupdirs = DelimStringToVector( pkg.cleanupdirs );
-
-	for( auto cleanupdir : cleanupdirs ) {
-		if( DispExecuteNoErr( "rm -rf " + PACKAGE_INSTALL_DIR + cleanupdir ) != 0 ) {
-			DispColoredData( CROSS, RED, true );
-			DispColoredData( " =>", "Unable to remove directory:",
-					PACKAGE_INSTALL_DIR + cleanupdir, RED, RED, CYAN, false );
-			DispColoredData( " !", CROSS, RED, RED, true );
-			return false;
-		}
-	}
 
 	DispColoredData( TICK, GREEN, true );
 	return true;

--- a/src/PackageManagement/PackageUninstaller.cpp
+++ b/src/PackageManagement/PackageUninstaller.cpp
@@ -113,7 +113,7 @@ bool UninstallUsingInstallManifest( const Package & pkg )
 	if( pkg.cleanupdirs.empty() )
 		return true;
 
-	DispColoredData( "Cleaning directories up ... ", FIRST_COL, false );
+	DispColoredData( " =>", "Cleaning directories up ... ", SECOND_COL, FIRST_COL, false );
 	auto cleanupdirs = DelimStringToVector( pkg.cleanupdirs );
 
 	for( auto cleanupdir : cleanupdirs ) {

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -333,6 +333,7 @@ bool PackageManager::RemoveInstalledEntry( const Package & pkg )
 			continue;
 		}
 		output.push_back( line );
+		std::cout << line << std::endl;
 	}
 
 	file.close();

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -110,6 +110,23 @@ int PackageManager::InstallMultiplePackages( std::vector< std::string > & packag
 	return retval;
 }
 
+int PackageManager::UninstallMultiplePackages()
+{
+	int retval = 0;
+
+	for( int i = 3; i < args.size(); ++i ) {
+		retval = UninstallPackage( args[ i ] );
+
+		if( retval != 0 )
+			break;
+
+		if( i != args.size() - 1 )
+			DispColoredData( "", FIRST_COL, true );
+	}
+
+	return retval;
+}
+
 int PackageManager::InstallPackage( std::string package, bool forceinstall )
 {
 	Package pkg;

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -51,7 +51,7 @@ int PackageManager::HandleCommand()
 				FIRST_COL, SECOND_COL, true );
 			return 1;
 		}
-		return UninstallPackage( args[ 3 ] );
+		return UninstallMultiplePackages();
 	}
 
 	if( args[ 2 ] == "update" ) {

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -333,7 +333,6 @@ bool PackageManager::RemoveInstalledEntry( const Package & pkg )
 			continue;
 		}
 		output.push_back( line );
-		std::cout << line << std::endl;
 	}
 
 	file.close();
@@ -347,7 +346,7 @@ bool PackageManager::RemoveInstalledEntry( const Package & pkg )
 	}
 
 	for( auto op : output ) {
-		file << line << std::endl;
+		file << op << std::endl;
 	}
 
 	file.close();

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -329,7 +329,7 @@ bool PackageManager::RemoveInstalledEntry( const Package & pkg )
 
 	while( std::getline( file, line ) ) {
 		TrimString( line );
-		if( line != pkg.name || line.empty() || line == "\n" ) {
+		if( line == pkg.name || line.empty() || line == "\n" ) {
 			continue;
 		}
 		output.push_back( line );

--- a/src/PackageManager.cpp
+++ b/src/PackageManager.cpp
@@ -206,7 +206,7 @@ int PackageManager::UninstallPackage( std::string package )
 		return 1;
 	}
 
-	if( !UninstallArchive( pkg, args ) ) {
+	if( !UninstallArchive( pkg ) ) {
 		DispColoredData( "Uninstallation failed!", CROSS, FIRST_COL, RED, true );
 		return 1;
 	}

--- a/src/ProjectManagement/ConfigMgr.cpp
+++ b/src/ProjectManagement/ConfigMgr.cpp
@@ -52,6 +52,8 @@ int ConfigMgr::CreateDefaultConfig( std::string project_dir )
 	parser.SetDataString( "Core", "MainSrc", "main." + data.lang );
 	parser.SetDataString( "Core", "OtherSrc", "" );
 
+	parser.SetDataString( "Core", "ExecEnv", "LD_LIBRARY_PATH=" + LIB_DIR_REPLACEMENT );
+
 	for( auto lib : data.deps ) {
 		if( !IsCompatible( data.lang, GetLibraryLang( lib ) ) )
 			continue;

--- a/src/ProjectManagement/ProjectExecuter.cpp
+++ b/src/ProjectManagement/ProjectExecuter.cpp
@@ -35,6 +35,8 @@ int ExecuteProject( std::vector< std::string > & args )
 
 	std::string command = execenv + "./build/" + projectname;
 
+	std::cout << command << std::endl;
+
 	if( args.size() > 3 ){
 
 		command += " ";

--- a/src/ProjectManagement/ProjectExecuter.cpp
+++ b/src/ProjectManagement/ProjectExecuter.cpp
@@ -7,7 +7,6 @@
 #include "../../include/ColorDefs.hpp"
 #include "../../include/DisplayFuncs.hpp"
 #include "../../include/StringFuncs.hpp"
-#include "../../include/DisplayExecute.hpp"
 
 #include "../../include/ProjectManagement/ProjectBuilder.hpp"
 #include "../../include/ProjectManagement/ConfigMgr.hpp"
@@ -49,5 +48,5 @@ int ExecuteProject( std::vector< std::string > & args )
 
 	DispColoredData( "\nExecuting Project...\n", BOLD_MAGENTA, true );
 
-	return DispExecuteNoErr( command, true );
+	return std::system( command.c_str() );
 }

--- a/src/ProjectManagement/ProjectExecuter.cpp
+++ b/src/ProjectManagement/ProjectExecuter.cpp
@@ -3,8 +3,11 @@
 #include <vector>
 #include <string>
 
+#include "../../include/Paths.hpp"
 #include "../../include/ColorDefs.hpp"
 #include "../../include/DisplayFuncs.hpp"
+#include "../../include/StringFuncs.hpp"
+#include "../../include/DisplayExecute.hpp"
 
 #include "../../include/ProjectManagement/ProjectBuilder.hpp"
 #include "../../include/ProjectManagement/ConfigMgr.hpp"
@@ -23,7 +26,14 @@ int ExecuteProject( std::vector< std::string > & args )
 
 	std::string projectname = conf.GetDataString( "Core", "Name" );
 
-	std::string command = "./build/" + projectname;
+	std::string execenv = conf.GetDataString( "Core", "ExecEnv" );
+
+	if( !execenv.empty() ) {
+		ReplaceInString( execenv, LIB_DIR_REPLACEMENT, PACKAGE_LIBRARY_INSTALL_DIR );
+		execenv += " ";
+	}
+
+	std::string command = execenv + "./build/" + projectname;
 
 	if( args.size() > 3 ){
 
@@ -39,5 +49,5 @@ int ExecuteProject( std::vector< std::string > & args )
 
 	DispColoredData( "\nExecuting Project...\n", BOLD_MAGENTA, true );
 
-	return std::system( command.c_str() );
+	return DispExecuteNoErr( command, true );
 }

--- a/src/ProjectManagement/ProjectExecuter.cpp
+++ b/src/ProjectManagement/ProjectExecuter.cpp
@@ -35,8 +35,6 @@ int ExecuteProject( std::vector< std::string > & args )
 
 	std::string command = execenv + "./build/" + projectname;
 
-	std::cout << command << std::endl;
-
 	if( args.size() > 3 ){
 
 		command += " ";

--- a/src/ProjectManagement/ProjectExecuter.cpp
+++ b/src/ProjectManagement/ProjectExecuter.cpp
@@ -27,6 +27,10 @@ int ExecuteProject( std::vector< std::string > & args )
 
 	std::string execenv = conf.GetDataString( "Core", "ExecEnv" );
 
+	// Replace , with space, and double space with single space.
+	ReplaceInString( execenv, ',', ' ' );
+	ReplaceInString( execenv, "  ", " " );
+
 	if( !execenv.empty() ) {
 		ReplaceInString( execenv, LIB_DIR_REPLACEMENT, PACKAGE_LIBRARY_INSTALL_DIR );
 		execenv += " ";


### PR DESCRIPTION
For the source packages without "make uninstall", another option is install_manifest.txt which will be read and all files in it will be deleted.

Also added a field in package's configuration - CleanupDirectories - in which comma separated directories can be added ( starting from after PACKAGE_INSTALL_DIR ) which have to be manually deleted after package is uninstalled.

Added a field "ExecEnv" in project's configuration which enables setting of env variables ( for example: LD_LIBRARY_PATH ) before executing the project with `project run`. It is comma separated.

Fixed a critical bug which caused the installed_pkgs file to be completely cleared when uninstalling a package.